### PR TITLE
remove .owl-stage on destroy owl.carousel instance

### DIFF
--- a/src/owl-child.component.ts
+++ b/src/owl-child.component.ts
@@ -53,7 +53,7 @@ export class OwlChild  implements OnInit, OnDestroy {
 
     destroyOwl() {
         if ( this.$owl) {
-            this.$owl.trigger('destroy.owl.carousel').removeClass('owl-loaded').find('.owl-item:empty').remove();
+            this.$owl.trigger('destroy.owl.carousel').removeClass('owl-loaded').find('.owl-stage:empty, .owl-item:empty').remove();
         }
     }
 }


### PR DESCRIPTION
Sometimes the `[items]` property could be an Observable and it might not ready at the time owl-carousel is initialized, which caused *ngFor to produce unexpected markup like this.

```html
<owl-carousel [items]="items" [options]="options" [carouselClasses]="['owl-theme']">
</owl-carousel>
```

Then, `owl-carousel` produces the following markup inside `<owl-carousel-child>`.

```html
<div class="owl-stage-outer"><div class="owl-stage"></div></div><div class="owl-nav disabled"><div class="owl-prev"><i class="fa fa-chevron-left"></i></div><div class="owl-next"><i class="fa fa-chevron-right"></i></div></div><div class="owl-dots disabled"></div>
```

and when `destroy` hook is called at this line.

https://github.com/mujtaba01/ngx-owl-carousel/blob/cab206f711a46a30add03fa7fb8286e75f597f5f/src/owl-child.component.ts#L56

it should has nothing left but it still and result in markup like this.

```html
<owl-carousel [items]="items" [options]="options" [carouselClasses]="['owl-theme']">
  <div class="owl-stage"></div>
</owl-carousel>
```

Once the Observable emit new value, **this will lead to unwanted item** when `initOwl()` is called again.

Why don't just use *ngIf to check if the binding contains value ?
----------------------------------------------------------------------------------

Of course, using `*ngIf="items?.length"` can avoid issue like this. But I'm thinking that it would be better if `ngx-owl-carousel` can handle this out-of-the-box :smiley:

Hope this help.
